### PR TITLE
fix: Remove typing_extensions dependency

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,6 +4,6 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = pynvml,requests,responses,setuptools,typing_extensions
+known_third_party = pynvml,requests,responses,setuptools
 skip_glob = /*
 not_skip = setup.py

--- a/co2_tracker_utils/cloud_logging.py
+++ b/co2_tracker_utils/cloud_logging.py
@@ -20,7 +20,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 from logging import getLogger
-from typing import Any, Callable, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 import requests
 

--- a/co2_tracker_utils/cloud_logging.py
+++ b/co2_tracker_utils/cloud_logging.py
@@ -23,7 +23,6 @@ from logging import getLogger
 from typing import Any, Callable, Dict, Optional, cast
 
 import requests
-from typing_extensions import TypedDict
 
 LOGGER = getLogger(__name__)
 
@@ -55,19 +54,9 @@ CLOUD_METADATA_MAPPING = {
     },
 }
 
-ProviderMapping = TypedDict(
-    "ProviderMapping",
-    {
-        "url": str,
-        "headers": Dict[str, str],
-        "postprocess_function": Optional[Callable[[Dict[str, Any]], Dict[str, Any]]],
-    },
-)
-CloudDetails = TypedDict("CloudDetails", {"provider": str, "metadata": Dict[str, Any]})
-
 
 def get_env_cloud_details(timeout=1):
-    # type: (int) -> Optional[CloudDetails]
+    # type: (int) -> Optional[Any]
     """
 
     >>> get_env_cloud_details()
@@ -90,7 +79,7 @@ def get_env_cloud_details(timeout=1):
     """
     for provider in CLOUD_METADATA_MAPPING.keys():
         try:
-            params = cast(ProviderMapping, CLOUD_METADATA_MAPPING[provider])
+            params = CLOUD_METADATA_MAPPING[provider]
             response = requests.get(
                 params["url"], headers=params["headers"], timeout=timeout
             )

--- a/meta.yaml
+++ b/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python
     - nvidia-ml==7.352.0 # Use same version as Pypi
     - requests>=2.18.4
-    - typing_extensions>=3.7.4
+    - typing>=3.7.4
 
 test:
   imports:
@@ -33,8 +33,7 @@ about:
   license: MIT
   summary: 'CO2 Tracker helpers'
   description: |
-    This module analyzes jpeg/jpeg2000/png/gif image header and
-    return image size.
+    CO2 Tracker helpers
   dev_url: https://github.com/comet-ml/co2-tracker-utils
   doc_url: https://pypi.python.org/comet-ml/co2-tracker-utils
   doc_source_url: https://github.com/comet-ml/co2-tracker-utils/blob/master/README.md

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ requirements = [
     "nvidia-ml-py3==7.352.0",  # Use the same version as of Conda
     "requests>=2.18.4",
     "typing>=3.7.4; python_version<'3.5'",
-    "typing_extensions>=3.7.4",
 ]
 
 setup(


### PR DESCRIPTION
The minimum version of the dependency is incompatible with the default version
of chainer on Google Colab.